### PR TITLE
fix(pytorch): Adapt to new Gym API for compatibility

### DIFF
--- a/pytorch/actor_critic.py
+++ b/pytorch/actor_critic.py
@@ -83,13 +83,23 @@ reward_history = []
 
 for episode in range(2000):
     state = env.reset()
+    if isinstance(state, tuple):
+        state = state[0]
     done = False
     total_reward = 0
 
     while not done:
         action, prob = agent.get_action(state)
-        next_state, reward, done, info = env.step(action)
-
+        try:
+            # For newer gym versions (>=0.26.0)
+            next_state, reward, terminated, truncated, info = env.step(action)
+            done = terminated or truncated
+        except ValueError:
+            # For older gym versions
+            next_state, reward, done, info = env.step(action)
+            if isinstance(info, dict) and 'TimeLimit.truncated' in info:
+                done = done and not info['TimeLimit.truncated']
+        
         agent.update(state, prob, reward, next_state, done)
 
         state = next_state

--- a/pytorch/dqn.py
+++ b/pytorch/dqn.py
@@ -7,6 +7,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
+from gym.wrappers import RecordVideo
+import os
 
 
 class ReplayBuffer:
@@ -25,7 +27,7 @@ class ReplayBuffer:
         data = random.sample(self.buffer, self.batch_size)
 
         state = torch.tensor(np.array([x[0] for x in data]), dtype=torch.float32)
-        action = torch.tensor(np.array([x[1] for x in data]).astype(np.long))
+        action = torch.tensor(np.array([x[1] for x in data]).astype(np.int64))#action = torch.tensor(np.array([x[1] for x in data]).astype(np.long))
         reward = torch.tensor(np.array([x[2] for x in data]).astype(np.float32))
         next_state = torch.tensor(np.array([x[3] for x in data]), dtype=torch.float32)
         done = torch.tensor(np.array([x[4] for x in data]).astype(np.int32))
@@ -96,7 +98,22 @@ class DQNAgent:
 
 episodes = 300
 sync_interval = 20
-env = gym.make('CartPole-v0')
+render_interval = 50  # 每50个episode渲染一次
+video_dir = "./dqn_videos"  # 更改视频保存目录
+if not os.path.exists(video_dir):
+    os.makedirs(video_dir)
+
+print(f"视频将保存到: {os.path.abspath(video_dir)}")
+
+# 使用RecordVideo包装环境，指定要记录的episodes
+base_env = gym.make('CartPole-v0', render_mode="rgb_array")
+env = RecordVideo(
+    base_env, 
+    video_dir,
+    episode_trigger=lambda x: x % render_interval == 0,  # 每render_interval个episode录制一次
+    name_prefix="cartpole-dqn"  # 添加前缀以区分不同的运行
+)
+
 agent = DQNAgent()
 reward_history = []
 
@@ -106,7 +123,7 @@ for episode in range(episodes):
         state, _ = state
     done = False
     total_reward = 0
-
+    
     while not done:
         action = agent.get_action(state)
         step_result = env.step(action)
@@ -128,3 +145,7 @@ for episode in range(episodes):
     reward_history.append(total_reward)
     if episode % 10 == 0:
         print("episode :{}, total reward : {}".format(episode, total_reward))
+
+# 添加环境关闭
+env.close()
+print(f"训练完成！视频已保存到 {os.path.abspath(video_dir)} 目录")

--- a/pytorch/dqn.py
+++ b/pytorch/dqn.py
@@ -24,10 +24,10 @@ class ReplayBuffer:
     def get_batch(self):
         data = random.sample(self.buffer, self.batch_size)
 
-        state = torch.tensor(np.stack([x[0] for x in data]))
+        state = torch.tensor(np.array([x[0] for x in data]), dtype=torch.float32)
         action = torch.tensor(np.array([x[1] for x in data]).astype(np.long))
         reward = torch.tensor(np.array([x[2] for x in data]).astype(np.float32))
-        next_state = torch.tensor(np.stack([x[3] for x in data]))
+        next_state = torch.tensor(np.array([x[3] for x in data]), dtype=torch.float32)
         done = torch.tensor(np.array([x[4] for x in data]).astype(np.int32))
         return state, action, reward, next_state, done
 
@@ -64,7 +64,7 @@ class DQNAgent:
         if np.random.rand() < self.epsilon:
             return np.random.choice(self.action_size)
         else:
-            state = torch.tensor(state[np.newaxis, :])
+            state = torch.tensor(state, dtype=torch.float32).unsqueeze(0)
             qs = self.qnet(state)
             return qs.argmax().item()
 
@@ -102,12 +102,21 @@ reward_history = []
 
 for episode in range(episodes):
     state = env.reset()
+    if isinstance(state, tuple):  # Handle new gym API
+        state, _ = state
     done = False
     total_reward = 0
 
     while not done:
         action = agent.get_action(state)
-        next_state, reward, done, info = env.step(action)
+        step_result = env.step(action)
+        
+        # Handle different gym versions
+        if len(step_result) == 5:  # Newer gym version (step returns 5 values)
+            next_state, reward, terminated, truncated, info = step_result
+            done = terminated or truncated
+        else:  # Older gym version (step returns 4 values)
+            next_state, reward, done, info = step_result
 
         agent.update(state, action, reward, next_state, done)
         state = next_state

--- a/pytorch/reinforce.py
+++ b/pytorch/reinforce.py
@@ -30,6 +30,8 @@ class Agent:
         self.optimizer = optim.Adam(self.pi.parameters(), lr=self.lr)
 
     def get_action(self, state):
+        if isinstance(state, tuple):
+            state = state[0]  # Extract the actual state from the tuple
         state = torch.tensor(state[np.newaxis, :])
         probs = self.pi(state)
         probs = probs[0]
@@ -64,7 +66,8 @@ for episode in range(3000):
 
     while not done:
         action, prob = agent.get_action(state)
-        next_state, reward, done, info = env.step(action)
+        next_state, reward, terminated, truncated, info = env.step(action)
+        done = terminated or truncated
 
         agent.add(reward, prob)
         state = next_state

--- a/pytorch/simple_pg.py
+++ b/pytorch/simple_pg.py
@@ -30,7 +30,9 @@ class Agent:
         self.optimizer = optim.Adam(self.pi.parameters(), lr=self.lr)
 
     def get_action(self, state):
-        state = torch.tensor(state[np.newaxis, :])
+        if isinstance(state, tuple):
+            state = state[0]  # Extract the observation from tuple if needed
+        state = torch.FloatTensor(state).unsqueeze(0)
         probs = self.pi(state)
         probs = probs[0]
         m = Categorical(probs)
@@ -60,13 +62,14 @@ agent = Agent()
 reward_history = []
 
 for episode in range(3000):
-    state = env.reset()
+    state, _ = env.reset()
     done = False
     total_reward = 0
 
     while not done:
         action, prob = agent.get_action(state)
-        next_state, reward, done, info = env.step(action)
+        next_state, reward, terminated, truncated, info = env.step(action)
+        done = terminated or truncated
 
         agent.add(reward, prob)
         state = next_state


### PR DESCRIPTION
This PR introduces changes **specifically within the `pytorch/` directory** to adapt the codebase for newer Gym/Gymnasium API versions.

**Problem:**
The original code within `pytorch/` was incompatible with newer Gym/Gymnasium API versions. This was due to changes in the return values of `env.reset()` and `env.step()`, and how states (sometimes tuples) are handled.

**Solution:**
This PR updates the code within `pytorch/` to align with the new Gym API:
* `get_action`: Now correctly handles tuple state inputs by extracting the main observation.
* `env.reset()`: Updated to `state, _ = env.reset()` to match the new API (returns observation and info).
* `env.step()`: Adapted to process five return values (`next_state, reward, terminated, truncated, info`) and now uses a combined `done = terminated or truncated` flag.

These changes ensure the `pytorch/` examples/code work correctly with environments using the updated API, such as CartPole.

**Testing:**
* Tested the changes in the `pytorch/` folder with: gym `0.26.2`, Python `3.9.13` on macOS `15.4.1 (Sequoia)`.