### PR TITLE
Resolved the issue of "IndexError: tensors used as indices must be long, byte or bool tensors"

### DIFF
--- a/pytorch/dqn.py
+++ b/pytorch/dqn.py
@@ -75,7 +75,8 @@ class DQNAgent:
 
         state, action, reward, next_state, done = self.replay_buffer.get_batch()
         qs = self.qnet(state)
-        q = qs[np.arange(len(action)), action]
+        # q = qs[np.arange(len(action)), action]
+        q = qs[torch.arange(len(action)), action.long()]
 
         next_qs = self.qnet_target(next_state)
         next_q = next_qs.max(1)[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy==1.22.0
+scipy==1.8.0
+matplotlib==3.5.0
+torch==1.8.0
+gym==0.23.0
+dezero==0.0.13
+pygame==2.1.2


### PR DESCRIPTION
The current code is experiencing issues because the library versions were not specified. To address this, I have included a requirements.txt file. 

Furthermore, this submission resolves an "IndexError: tensors used as indices must be long, byte or bool tensors" that was encountered in the PyTorch version of dqn.py during execution.